### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Publish Snapshot to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         if: "!contains(github.ref, 'refs/tags/v') && !contains(github.ref, 'refs/pull')"
         with:
           name: tarioch/subsonicapiproxy
@@ -22,7 +22,7 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Publish Release to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         if: contains(github.ref, 'refs/tags/v')
         with:
           name: tarioch/subsonicapiproxy


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore